### PR TITLE
feat(mobile): add iOS Password AutoFill support to authentication scr…

### DIFF
--- a/docs/adr/016-ios-password-autofill-support.md
+++ b/docs/adr/016-ios-password-autofill-support.md
@@ -1,0 +1,43 @@
+# ADR-016: iOS Password AutoFill Support for Authentication Screens
+
+## Status
+Accepted
+
+## Context
+iOS users on the Guidr app could not access 1Password or iCloud Keychain password suggestions on the LoginScreen and RegistrationScreen. While React Native TextInput components had `textContentType` props set, the `autoComplete` prop was missing. iOS Password AutoFill requires **both** props to function correctly.
+
+Additionally, email fields were incorrectly using `textContentType="username"` instead of `textContentType="emailAddress"`, which prevented email-specific AutoFill suggestions.
+
+## Decision
+Add `autoComplete` props to all TextInput components in LoginScreen and RegistrationScreen, and correct the `textContentType` for email fields:
+
+### LoginScreen Changes
+- Email field: Change `textContentType="username"` → `textContentType="emailAddress"`, add `autoComplete="email"`
+- Password field: Add `autoComplete="current-password"`
+
+### RegistrationScreen Changes
+- Email field: Change `textContentType="username"` → `textContentType="emailAddress"`, add `autoComplete="email"`
+- Password field: Add `autoComplete="new-password"`
+- Confirm password field: Add `autoComplete="new-password"`
+
+## Consequences
+
+### Benefits
+- Users with 1Password, iCloud Keychain, or other iOS password managers can now see password suggestions
+- Improved UX for login and registration flows
+- Better security by encouraging password manager usage
+- No Android regressions (Android ignores iOS-specific props)
+
+### Implementation Details
+- `autoComplete` prop is specific to iOS; Android does not recognize it
+- `textContentType` values remain unchanged on Android and don't affect functionality
+- All changes are backward-compatible with existing code
+
+## Verification
+- Unit tests verify `autoComplete` and `textContentType` props are correctly set
+- iOS simulator testing confirms 1Password and Keychain suggestions appear
+- Android regression testing confirms no behavior changes
+
+## Related ADRs
+- ADR-006: Admin User Authorization
+- ADR-007: User-Based Admin Mode (Mobile)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,12 @@ What becomes easier or harder as a result of this change?
 - [ADR-008: RBAC and Comprehensive Audit Logging System](./008-rbac-and-audit-logging.md) - Accepted
 - [ADR-009: Server Health Validation and URL Normalization](./009-server-health-validation.md) - Accepted
 - [ADR-010: Strict Type Safety and Import Rules](./010-strict-type-safety-rules.md) - Accepted
+- [ADR-011: Fastlane Match Certificate Management](./011-fastlane-match-certificate-management.md) - Accepted
+- [ADR-012: API Server Crash Notifications](./012-api-server-crash-notifications.md) - Accepted
+- [ADR-013: iOS TestFlight Build Optimization](./013-ios-testflight-build-optimization.md) - Accepted
+- [ADR-014: iOS 26 SDK Upgrade](./014-ios-26-sdk-upgrade.md) - Accepted
+- [ADR-015: ECDSA Timing Attack Mitigation](./015-ecdsa-timing-attack-mitigation.md) - Accepted
+- [ADR-016: iOS Password AutoFill Support for Authentication Screens](./016-ios-password-autofill-support.md) - Accepted
 
 ## Updating ADRs
 

--- a/mobile/src/presentation/screens/LoginScreen.test.tsx
+++ b/mobile/src/presentation/screens/LoginScreen.test.tsx
@@ -87,6 +87,26 @@ describe('LoginScreen', () => {
       expect(passwordInput.props['secureTextEntry']).toBe(true)
     })
 
+    it('should have correct autoComplete attributes for iOS Password AutoFill', () => {
+      const { getByPlaceholderText } = render(
+        <LoginScreen
+          authStorage={mockAuthStorage}
+          authClient={mockAuthClient}
+          onComplete={mockOnComplete}
+          onChangeServer={mockOnChangeServer}
+          onRegister={mockOnRegister}
+        />
+      )
+
+      const emailInput = getByPlaceholderText('email@example.com')
+      const passwordInput = getByPlaceholderText('Password')
+
+      expect(emailInput.props['autoComplete']).toBe('email')
+      expect(emailInput.props['textContentType']).toBe('emailAddress')
+      expect(passwordInput.props['autoComplete']).toBe('current-password')
+      expect(passwordInput.props['textContentType']).toBe('password')
+    })
+
     it('should not render version display (hidden for non-admin users)', () => {
       const { queryByTestId } = render(
         <LoginScreen

--- a/mobile/src/presentation/screens/LoginScreen.tsx
+++ b/mobile/src/presentation/screens/LoginScreen.tsx
@@ -104,7 +104,8 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({
             autoCapitalize="none"
             autoCorrect={false}
             keyboardType="email-address"
-            textContentType="username"
+            textContentType="emailAddress"
+            autoComplete="email"
             editable={!loading}
           />
 
@@ -116,6 +117,7 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({
             onChangeText={handlePasswordChange}
             secureTextEntry
             textContentType="password"
+            autoComplete="current-password"
             editable={!loading}
           />
 

--- a/mobile/src/presentation/screens/RegistrationScreen.test.tsx
+++ b/mobile/src/presentation/screens/RegistrationScreen.test.tsx
@@ -94,6 +94,28 @@ describe('RegistrationScreen', () => {
       expect(passwordInput.props['secureTextEntry']).toBe(true)
       expect(confirmPasswordInput.props['secureTextEntry']).toBe(true)
     })
+
+    it('should have correct autoComplete attributes for iOS Password AutoFill', () => {
+      const { getByPlaceholderText } = render(
+        <RegistrationScreen
+          authStorage={mockAuthStorage}
+          authClient={mockAuthClient}
+          onComplete={mockOnComplete}
+          onBackToLogin={mockOnBackToLogin}
+        />
+      )
+
+      const emailInput = getByPlaceholderText('email@example.com')
+      const passwordInput = getByPlaceholderText('Password (min 6 characters)')
+      const confirmPasswordInput = getByPlaceholderText('Confirm Password')
+
+      expect(emailInput.props['autoComplete']).toBe('email')
+      expect(emailInput.props['textContentType']).toBe('emailAddress')
+      expect(passwordInput.props['autoComplete']).toBe('new-password')
+      expect(passwordInput.props['textContentType']).toBe('newPassword')
+      expect(confirmPasswordInput.props['autoComplete']).toBe('new-password')
+      expect(confirmPasswordInput.props['textContentType']).toBe('newPassword')
+    })
   })
 
   describe('user interaction', () => {

--- a/mobile/src/presentation/screens/RegistrationScreen.tsx
+++ b/mobile/src/presentation/screens/RegistrationScreen.tsx
@@ -125,7 +125,8 @@ export const RegistrationScreen: React.FC<RegistrationScreenProps> = ({
             autoCapitalize="none"
             autoCorrect={false}
             keyboardType="email-address"
-            textContentType="username"
+            textContentType="emailAddress"
+            autoComplete="email"
             editable={!loading}
           />
 
@@ -137,6 +138,7 @@ export const RegistrationScreen: React.FC<RegistrationScreenProps> = ({
             onChangeText={handlePasswordChange}
             secureTextEntry
             textContentType="newPassword"
+            autoComplete="new-password"
             editable={!loading}
           />
 
@@ -148,6 +150,7 @@ export const RegistrationScreen: React.FC<RegistrationScreenProps> = ({
             onChangeText={handleConfirmPasswordChange}
             secureTextEntry
             textContentType="newPassword"
+            autoComplete="new-password"
             editable={!loading}
           />
 


### PR DESCRIPTION
…eens

Add autoComplete props to LoginScreen and RegistrationScreen TextInput components to enable 1Password and iCloud Keychain suggestions on iOS.

Changes:
- LoginScreen: Add autoComplete='email' and autoComplete='current-password'
- RegistrationScreen: Add autoComplete='email' and autoComplete='new-password'
- Fix textContentType from 'username' to 'emailAddress' for email fields
- Add tests verifying autoComplete and textContentType props

Resolves iOS Password AutoFill issue where 1Password suggestions were not appearing. Cross-platform compatible (no Android regressions).